### PR TITLE
Generate line number information in class files

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -21,13 +21,16 @@ classFile = mkClassFile java7 [Public, Super] mainClass Nothing [] []
     mkMethodDef mainClass [Public, Static] "main" [jarray jstring] void $
         startLabel loop
      <> markStackMap
+     <> emitLineNumber (ln 5)  
      <> iconst jint 1
      <> iconst jint 1
      <> iadd
      <> ifeq (goto loop) mempty
+     <> emitLineNumber (ln 6)
      <> vreturn
   ]
   where loop = mkLabel 1
+        ln = mkLineNumber
 
 dumpStackMap :: Code -> IO ()
 dumpStackMap (Code consts instr) = do

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -26,7 +26,6 @@ classFile = mkClassFile java7 [Public, Super] mainClass Nothing [] []
      <> iconst jint 1
      <> iadd
      <> ifeq (goto loop) mempty
-     <> emitLineNumber (ln 6)
      <> vreturn
   ]
   where loop = mkLabel 1

--- a/src/Codec/JVM/ASM/Code.hs
+++ b/src/Codec/JVM/ASM/Code.hs
@@ -717,3 +717,5 @@ arraylength ft =
      IT.op OP.arraylength
   <> modifyStack ( CF.push jint . CF.pop ft )
 
+emitLineNumber :: LineNumber -> Code
+emitLineNumber = mkCode' . IT.recordLineNumber 

--- a/src/Codec/JVM/ASM/Code/Instr.hs
+++ b/src/Codec/JVM/ASM/Code/Instr.hs
@@ -130,11 +130,14 @@ recordBranch bt = do
   off <- getOffset
   modify' $ \s -> s { isLastBranch = HasBranch bt (Offset off) }
 
-recordLineNumber :: LineNumber -> InstrM ()
-recordLineNumber ln = do
+recordLineNumber' :: LineNumber -> InstrM ()
+recordLineNumber' ln = do
   off <- getOffset
   modify' $ \s@InstrState { isLineNumberTable = lnt } ->
               s { isLineNumberTable = insertLNT (Offset off) ln lnt } 
+
+recordLineNumber :: LineNumber -> Instr
+recordLineNumber = Instr . recordLineNumber'
 
 gotoInstr :: Special -> InstrM ()
 gotoInstr = gotoInstrSpec OP.goto

--- a/src/Codec/JVM/ASM/Code/Types.hs
+++ b/src/Codec/JVM/ASM/Code/Types.hs
@@ -32,11 +32,13 @@ insertSMT :: Int -> CtrlFlow -> StackMapTable -> StackMapTable
 insertSMT k v (StackMapTable sm) = StackMapTable $ IntMap.insert k v sm
 
 newtype LineNumber = LineNumber Int
+  deriving (Show, Eq)
 
 mkLineNumber :: Int -> LineNumber
 mkLineNumber = LineNumber
 
 newtype LineNumberTable = LineNumberTable (IntMap LineNumber)
+  deriving (Show, Eq)
 
 instance Monoid LineNumberTable where
   mempty = LineNumberTable mempty

--- a/src/Codec/JVM/ASM/Code/Types.hs
+++ b/src/Codec/JVM/ASM/Code/Types.hs
@@ -33,6 +33,9 @@ insertSMT k v (StackMapTable sm) = StackMapTable $ IntMap.insert k v sm
 
 newtype LineNumber = LineNumber Int
 
+mkLineNumber :: Int -> LineNumber
+mkLineNumber = LineNumber
+
 newtype LineNumberTable = LineNumberTable (IntMap LineNumber)
 
 instance Monoid LineNumberTable where
@@ -40,8 +43,8 @@ instance Monoid LineNumberTable where
   mappend (LineNumberTable x) (LineNumberTable y)
     = LineNumberTable $ union' x y
 
-fromListLNT :: LineNumberTable -> [(Offset,LineNumber)]
-fromListLNT (LineNumberTable m) = map (\(off,ln) -> (Offset off,ln)) $ IntMap.assocs m
+toListLNT :: LineNumberTable -> [(Offset,LineNumber)]
+toListLNT (LineNumberTable m) = map (\(off,ln) -> (Offset off,ln)) $ IntMap.assocs m
 
 insertLNT :: Offset -> LineNumber -> LineNumberTable -> LineNumberTable
 insertLNT (Offset off) ln (LineNumberTable lnt) =

--- a/src/Codec/JVM/Attr.hs
+++ b/src/Codec/JVM/Attr.hs
@@ -236,10 +236,10 @@ unpackAttr :: Attr -> [Const]
 unpackAttr attr = CUTF8 (attrName attr) : restAttributes
   where restAttributes =
           case attr of
-            ACode _ _ _ xs       -> concatMap unpackAttr xs
-            ASignature sig       -> [CUTF8 $ generateSignature sig]
-            ASourceFile f        -> [CUTF8 $ f]
-            _                    -> []
+            ACode _ _ _ xs -> concatMap unpackAttr xs
+            ASignature sig -> [CUTF8 $ generateSignature sig]
+            ASourceFile f  -> [CUTF8 $ f]
+            _              -> []
 
 putAttr :: String -> Maybe Int -> ConstPool -> Attr -> Put
 putAttr debug mCodeSize cp attr = do
@@ -344,7 +344,8 @@ toAttrs cp code = [ACode maxStack' maxLocals' xs attrs']
         maxStack'          = CF.maxStack cf
         attrs              = if null frames then [] else [AStackMapTable frames]
         frames             = toStackMapFrames smt
-        attrs' = (if lnt == mempty then [] else [ALineNumberTable lnt]) ++ attrs
+        attrs'             = attrs ++ if lnt == mempty then []
+                                      else [ALineNumberTable lnt]
         
 toStackMapFrames :: StackMapTable -> [(Offset, StackMapFrame)]
 toStackMapFrames (StackMapTable smt)

--- a/src/Codec/JVM/Method.hs
+++ b/src/Codec/JVM/Method.hs
@@ -25,7 +25,8 @@ data MethodInfo = MethodInfo
 -- TODO: This is very ugly hack
 unpackMethodInfo :: MethodInfo -> [Const]
 unpackMethodInfo _  = [ CUTF8 $ attrName (ACode a a a a)
-                      , CUTF8 $ attrName (AStackMapTable a)]
+                      , CUTF8 $ attrName (AStackMapTable a)
+                      , CUTF8 $ attrName (ALineNumberTable a)]
   where a = undefined
 
 putMethodInfo :: String -> ConstPool -> MethodInfo -> Put


### PR DESCRIPTION
To achieve https://github.com/typelead/eta/issues/189

It seems to work with an output similar to javac, with the actual example emitting line info:
```haskell
classFile = mkClassFile java7 [Public, Super] mainClass Nothing [] []
  [
    mkMethodDef mainClass [Public, Static] "main" [jarray jstring] void $
        startLabel loop
     <> markStackMap
     <> emitLineNumber (ln 5)  
     <> iconst jint 1
     <> iconst jint 1
     <> iadd
     <> ifeq (goto loop) mempty
     <> vreturn
  ]
  where loop = mkLabel 1
        ln = mkLineNumber
```
The javap -v outputs:
```
D:\ws\eta\codec-jvm\example>javap -v Test
Classfile /D:/ws/eta/codec-jvm/example/Test.class
  Last modified 22-ago-2017; size 216 bytes
  MD5 checksum 13c31bfdcfe899fbe89f1a5bcab69892
public class Test
  minor version: 0
  major version: 51
  flags: ACC_PUBLIC, ACC_SUPER
Constant pool:
   #1 = Class              #2             //  Test
   #2 = Utf8               Test
   #3 = Class              #4             //  java/lang/Object
   #4 = Utf8               java/lang/Object
   #5 = Utf8               main
   #6 = Utf8               ([Ljava/lang/String;)V
   #7 = Class              #8             //  "[Ljava/lang/String;"
   #8 = Utf8               [Ljava/lang/String;
   #9 = Utf8               Code
  #10 = Utf8               StackMapTable
  #11 = Utf8               LineNumberTable
{
  public static void main(java.lang.String[]);
    flags: ACC_PUBLIC, ACC_STATIC
    Code:
      stack=2, locals=1, args_size=1
         0: iconst_1
         1: iconst_1
         2: iadd
         3: ifeq          9
         6: goto          12
         9: goto          0
        12: return
      StackMapTable: number_of_entries = 3
           frame_type = 0 /* same */
           frame_type = 8 /* same */
           frame_type = 2 /* same */

      LineNumberTable:
        line 5: 0
}
```
and the class file is executable, of course.

But i am afraid that opening the class with the popular java decompiler jd-gui it doesnt show the line number in de code decompiled. It shows them for this class compiled with `javac -g:lines MyTest.java`:
```
Classfile /D:/Trabajo/NO-SALVAR/jneira/ws/eta/codec-jvm/example/MyTest.class
  Last modified 22-ago-2017; size 389 bytes
  MD5 checksum 3e4a12641dd9e6104c8b5bafc1358576
public class MyTest
  minor version: 0
  major version: 51
  flags: ACC_PUBLIC, ACC_SUPER
Constant pool:
   #1 = Methodref          #6.#14         //  java/lang/Object."<init>":()V
   #2 = Fieldref           #15.#16        //  java/lang/System.out:Ljava/io/Prin
tStream;
   #3 = String             #17            //  MyTest
   #4 = Methodref          #18.#19        //  java/io/PrintStream.println:(Ljava
/lang/String;)V
   #5 = Class              #17            //  MyTest
   #6 = Class              #20            //  java/lang/Object
   #7 = Utf8               <init>
   #8 = Utf8               ()V
   #9 = Utf8               Code
  #10 = Utf8               LineNumberTable
  #11 = Utf8               main
  #12 = Utf8               ([Ljava/lang/String;)V
  #13 = Utf8               StackMapTable
  #14 = NameAndType        #7:#8          //  "<init>":()V
  #15 = Class              #21            //  java/lang/System
  #16 = NameAndType        #22:#23        //  out:Ljava/io/PrintStream;
  #17 = Utf8               MyTest
  #18 = Class              #24            //  java/io/PrintStream
  #19 = NameAndType        #25:#26        //  println:(Ljava/lang/String;)V
  #20 = Utf8               java/lang/Object
  #21 = Utf8               java/lang/System
  #22 = Utf8               out
  #23 = Utf8               Ljava/io/PrintStream;
  #24 = Utf8               java/io/PrintStream
  #25 = Utf8               println
  #26 = Utf8               (Ljava/lang/String;)V
{
  public MyTest();
    flags: ACC_PUBLIC
    Code:
      stack=1, locals=1, args_size=1
         0: aload_0
         1: invokespecial #1                  // Method java/lang/Object."<init>
":()V
         4: return
      LineNumberTable:
        line 1: 0

  public static void main(java.lang.String[]);
    flags: ACC_PUBLIC, ACC_STATIC
    Code:
      stack=2, locals=1, args_size=1
         0: getstatic     #2                  // Field java/lang/System.out:Ljav
a/io/PrintStream;
         3: ldc           #3                  // String MyTest
         5: invokevirtual #4                  // Method java/io/PrintStream.prin
tln:(Ljava/lang/String;)V
         8: return
      LineNumberTable:
        line 5: 0
      StackMapTable: number_of_entries = 1
           frame_type = 0 /* same */

}
```
The only significative diff is with javac the LineNumberTable is generated for the class definition too. I suppose the order in the attr generation doesnt matter.

However, i still have not tested if the stacktraces and debuggers can use the actual LineNumberTable generated