### PR TITLE
Fix all warnings, GHC 8.0 to 8.4

### DIFF
--- a/codec-jvm.cabal
+++ b/codec-jvm.cabal
@@ -32,6 +32,11 @@ library
     Codec.JVM.Method
     Codec.JVM.Opcode
     Codec.JVM.Types
+
+  -- See https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0#base-4.9.0.0
+  if impl(ghc >= 8.0)
+    ghc-options:  -Wno-redundant-constraints -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+
   build-depends:
       base                >= 4.6.0.1    && < 5
     , binary              >= 0.7        && < 0.9
@@ -42,8 +47,10 @@ library
     , mtl
     , array
     , transformers
-  default-extensions: NamedFieldPuns
 
+  if !impl(ghc >= 8)
+    build-depends:     semigroups                      >= 0.10 && < 0.19
+                     , fail == 4.9.*
 
 executable example
     hs-source-dirs:      example

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -21,14 +21,14 @@ classFile = mkClassFileWithAttrs java7 [Public, Super] mainClass Nothing [] [] [
     mkMethodDef mainClass [Public, Static] "main" [jarray jstring] void $
         startLabel loop
      <> markStackMap
-     <> emitLineNumber (ln 5)  
+     <> emitLineNumber (ln 5)
      <> iconst jint 1
      <> iconst jint 1
      <> iadd
      <> ifeq (goto loop) mempty
      <> vreturn
   ] (const False)
-  where srcFile = mkSourceFileAttr "Main.hs" 
+  where srcFile = mkSourceFileAttr "Main.hs"
         loop = mkLabel 1
         ln = mkLineNumber
 

--- a/src/Codec/JVM/ASM/Code/Instr.hs
+++ b/src/Codec/JVM/ASM/Code/Instr.hs
@@ -2,7 +2,7 @@
 module Codec.JVM.ASM.Code.Instr where
 
 import Control.Monad.IO.Class
-import Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.State
 import Control.Monad.Reader
 import Data.ByteString (ByteString)
@@ -65,7 +65,9 @@ instance Monad InstrM where
           case runInstrM (f x) e s' of
             (# x', s'' #) -> (# x', s'' #)
 
-instance MonadFail InstrM where
+  fail = Fail.fail
+
+instance Fail.MonadFail InstrM where
   fail = error
 
 instance MonadIO InstrM where

--- a/src/Codec/JVM/Attr.hs
+++ b/src/Codec/JVM/Attr.hs
@@ -2,7 +2,7 @@
 module Codec.JVM.Attr where
 
 import Data.Maybe (mapMaybe, fromMaybe)
-import Data.Monoid ((<>))
+import Data.Semigroup
 import Data.Map.Strict (Map)
 import Data.ByteString (ByteString)
 import Data.Foldable (traverse_)
@@ -29,6 +29,8 @@ import Codec.JVM.ConstPool (ConstPool, putIx, unpack)
 import Codec.JVM.Internal
 import Codec.JVM.Types (PrimType(..), IClassName(..),
                         AccessFlag(..), mkFieldDesc', putAccessFlags, prim)
+
+import Prelude
 
 type ParameterName = Text
 
@@ -214,17 +216,14 @@ newtype InnerClassMap = InnerClassMap (Map Text InnerClass)
 innerClassElems :: InnerClassMap -> [InnerClass]
 innerClassElems (InnerClassMap m) = Map.elems m
 
--- Left-biased monoid. Not commutative
-instance Monoid InnerClassMap where
-  mempty = InnerClassMap mempty
-  mappend (InnerClassMap x) (InnerClassMap y) =
-    InnerClassMap $ x `Map.union` y
-
-#if MIN_VERSION_base(4,10,0)
+-- Left-biased semigroup. Not commutative
 instance Semigroup InnerClassMap where
   (<>) (InnerClassMap x) (InnerClassMap y) =
     InnerClassMap $ x `Map.union` y
-#endif
+
+instance Monoid InnerClassMap where
+  mempty = InnerClassMap mempty
+  mappend = (<>)
 
 instance Show Attr where
   show (AInnerClasses icm) = "AInnerClasses = " ++ show icm

--- a/src/Codec/JVM/Class.hs
+++ b/src/Codec/JVM/Class.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings, RecordWildCards, NamedFieldPuns #-}
 module Codec.JVM.Class where
 
 import Data.Binary.Get


### PR DESCRIPTION
I received a bunch of warnings when compiling this, and it looks like the semigroup instances were non-canonical.

I also fixed up the commented example so it compiles and prints 42. It looks like the library has shifted since it was written.